### PR TITLE
docs: Update readme with error caused by no FE config

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To run the server:
   `` export JAVA_HOME=`/usr/libexec/java_home -v 1.8` ``.
 
 `Error injecting constructor, com.google.auth.ServiceAccountSigner$SigningException: Failed to sign the provided bytes`
-- Fill in the required 'Fleet engine' configuration in `src/main/config.properties`.
+- Fill in the required Fleet Engine configuration in `src/main/resources/config.properties`.
 
 ## Endpoints
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ To run the server:
 - Set the Java version to 8 by running the command
   `` export JAVA_HOME=`/usr/libexec/java_home -v 1.8` ``.
 
+`Error injecting constructor, com.google.auth.ServiceAccountSigner$SigningException: Failed to sign the provided bytes`
+- Fill in the required 'Fleet engine' configuration in `src/main/config.properties`.
+
 ## Endpoints
 
 These are the supported endpoints and how to interact with them:


### PR DESCRIPTION
This adds to our 'readme' the error thrown when user hasn't filled the 'FE' configuration.
Happened to me a couple of times while working locally that I dismissed the changes to 'config.properties' and forgot to bring them back.