### PR TITLE
feat: Serialize Date objects to Unix timestamps in JSON

### DIFF
--- a/src/main/java/com/example/provider/json/DateSerializer.java
+++ b/src/main/java/com/example/provider/json/DateSerializer.java
@@ -1,0 +1,33 @@
+/* Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.provider.json;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import java.lang.reflect.Type;
+import java.util.Date;
+
+/**
+ * Serializer for Date object to provide the number of milliseconds since the Unix epoch.
+ */
+final class DateSerializer implements JsonSerializer<Date> {
+
+  @Override
+  public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
+    return src == null ? null : new JsonPrimitive(src.getTime());
+  }
+}

--- a/src/main/java/com/example/provider/json/GsonProvider.java
+++ b/src/main/java/com/example/provider/json/GsonProvider.java
@@ -19,6 +19,7 @@ import com.google.gson.GsonBuilder;
 import com.google.type.LatLng;
 import google.maps.fleetengine.v1.Trip;
 import google.maps.fleetengine.v1.Vehicle;
+import java.util.Date;
 
 /**
  * Provider for Gson after setting custom serializer and deserializer.
@@ -43,6 +44,7 @@ public final class GsonProvider {
     gsonBuilder
         .registerTypeAdapter(Vehicle.class, new VehicleSerializer())
         .registerTypeAdapter(Trip.class, new TripSerializer())
+        .registerTypeAdapter(Date.class, new DateSerializer())
         .registerTypeAdapter(LatLng.class, new LatLngDeserializer())
         .setPrettyPrinting();
     gson = gsonBuilder.create();


### PR DESCRIPTION
The `GET /token/:tokenType` endpoint currently returns tokens' creation and expiration timestamps as strings, such as "Feb 27, 2022, 8:15:50 PM". These lack the timezone and are thus not useful for token management. This PR makes the JSON serializer converts a Java `Date` object to a Unix timestamp instead of a string.
