### PR TITLE
feat: Accept trip ID/vehicle ID when creating auth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ These are the supported endpoints and how to interact with them:
 #### GET
 
 Retrieves a signed JWT to be used to communicate with the Fleet Engine. The
-token will expire after 60 minutes of its creation. Supported values for the
-token type are `driver` and `consumer`.
+token will expire after 60 minutes of its creation.
 
 ```
-GET /token/:tokenType
+GET /token/driver/:vehicleId
+GET /token/consumer/:tripId
 ```
 
 ### Vehicle

--- a/src/main/java/com/example/provider/TokenServlet.java
+++ b/src/main/java/com/example/provider/TokenServlet.java
@@ -53,7 +53,14 @@ public class TokenServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     ServletUtils.setStandardResponseHeaders(response);
 
-    String tokenType = request.getPathInfo().substring(1);
+    String tokenType;
+    String pathInfo = request.getPathInfo();
+    int separatorIndex = pathInfo.indexOf("/", 1);
+    if (separatorIndex != -1) {
+      tokenType = pathInfo.substring(1, separatorIndex);
+    } else {
+      tokenType = pathInfo.substring(1);
+    }
     FleetEngineTokenType tokenTypeEnum;
     try {
       tokenTypeEnum = FleetEngineTokenType.valueOf(Ascii.toUpperCase(tokenType));
@@ -70,10 +77,20 @@ public class TokenServlet extends HttpServlet {
     try {
       switch (tokenTypeEnum) {
         case DRIVER:
-          authToken = this.minter.getDriverToken(VehicleClaims.create());
+          if (separatorIndex != -1) {
+            String vehicleId = pathInfo.substring(separatorIndex + 1);
+            authToken = this.minter.getDriverToken(VehicleClaims.create(vehicleId));
+          } else {
+            authToken = this.minter.getDriverToken(VehicleClaims.create());
+          }
           break;
         case CONSUMER:
-          authToken = this.minter.getConsumerToken(TripClaims.create());
+          if (separatorIndex != -1) {
+            String tripId = pathInfo.substring(separatorIndex + 1);
+            authToken = this.minter.getConsumerToken(TripClaims.create(tripId));
+          } else {
+            authToken = this.minter.getConsumerToken(TripClaims.create());
+          }
           break;
         default:
           logger.severe("Requested token for tokenType [%s], but it should not get here.");


### PR DESCRIPTION
Add the new endpoint `GET /token/:tokenType/:id`. The `GET /token/:tokenType` endpoint will be removed once the sample apps are updated to pass the trip/vehicle ID to the provider.