### PR TITLE
fix: Fix LatLng JSON serialization

### DIFF
--- a/src/main/java/com/example/provider/json/SerializedLatLng.java
+++ b/src/main/java/com/example/provider/json/SerializedLatLng.java
@@ -1,4 +1,4 @@
-/* Copyright 2020 Google LLC
+/* Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,32 @@ import com.google.auto.value.AutoValue;
 
 /** Representation of terminal location. */
 @AutoValue
-abstract class SerializedLocation {
+abstract class SerializedLatLng {
 
-  abstract SerializedLatLng point();
+  abstract double latitude();
+
+  abstract double longitude();
+
+  // For backward compatibility.
+  abstract double latitude_();
+
+  // For backward compatibility.
+  abstract double longitude_();
 
   static Builder newBuilder() {
-    return new AutoValue_SerializedLocation.Builder();
+    return new AutoValue_SerializedLatLng.Builder();
   }
 
   @AutoValue.Builder
   abstract static class Builder {
-    abstract Builder setPoint(SerializedLatLng point);
+    abstract Builder setLatitude(double latitude);
 
-    abstract SerializedLocation build();
+    abstract Builder setLongitude(double longitude);
+
+    abstract Builder setLatitude_(double latitude_);
+
+    abstract Builder setLongitude_(double longitude_);
+
+    abstract SerializedLatLng build();
   }
 }

--- a/src/main/java/com/example/provider/json/TripSerializer.java
+++ b/src/main/java/com/example/provider/json/TripSerializer.java
@@ -20,6 +20,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
+import com.google.type.LatLng;
 import google.maps.fleetengine.v1.Trip;
 import java.lang.reflect.Type;
 import java.util.List;
@@ -30,31 +31,52 @@ final class TripSerializer implements JsonSerializer<Trip> {
 
   @Override
   public JsonElement serialize(Trip src, Type typeOfSrc, JsonSerializationContext context) {
+    LatLng pickupLatLng = src.getPickupPoint().getPoint();
     Waypoint pickupWaypoint =
         Waypoint.newBuilder()
-            .setLocation(
-                SerializedLocation.newBuilder().setPoint(src.getPickupPoint().getPoint()).build())
+            .setLocation(SerializedLocation.newBuilder()
+                .setPoint(SerializedLatLng.newBuilder()
+                    .setLatitude(pickupLatLng.getLatitude())
+                    .setLongitude(pickupLatLng.getLongitude())
+                    .setLatitude_(pickupLatLng.getLatitude())
+                    .setLongitude_(pickupLatLng.getLongitude())
+                    .build())
+                .build())
             .setWaypointType(WaypointType.PICKUP_WAYPOINT_TYPE)
             .build();
 
+    LatLng dropoffLatLng = src.getDropoffPoint().getPoint();
     Waypoint dropoffWaypoint =
         Waypoint.newBuilder()
-            .setLocation(
-                SerializedLocation.newBuilder().setPoint(src.getDropoffPoint().getPoint()).build())
+            .setLocation(SerializedLocation.newBuilder()
+                .setPoint(SerializedLatLng.newBuilder()
+                    .setLatitude(dropoffLatLng.getLatitude())
+                    .setLongitude(dropoffLatLng.getLongitude())
+                    .setLatitude_(dropoffLatLng.getLatitude())
+                    .setLongitude_(dropoffLatLng.getLongitude())
+                    .build())
+                .build())
             .setWaypointType(WaypointType.DROP_OFF_WAYPOINT_TYPE)
             .build();
 
     List<Waypoint> intermediateWaypoints =
         src.getIntermediateDestinationsList().stream()
             .map(
-                destination ->
-                    Waypoint.newBuilder()
-                        .setLocation(
-                            SerializedLocation.newBuilder()
-                                .setPoint(destination.getPoint())
+                destination -> {
+                    LatLng latLng = destination.getPoint();
+                    return Waypoint.newBuilder()
+                        .setLocation(SerializedLocation.newBuilder()
+                            .setPoint(SerializedLatLng.newBuilder()
+                                .setLatitude(latLng.getLatitude())
+                                .setLongitude(latLng.getLongitude())
+                                .setLatitude_(latLng.getLatitude())
+                                .setLongitude_(latLng.getLongitude())
                                 .build())
+                            .build())
                         .setWaypointType(WaypointType.INTERMEDIATE_DESTINATION_WAYPOINT_TYPE)
-                        .build())
+                        .build();
+                }
+            )
             .collect(Collectors.toList());
     ;
 

--- a/src/main/java/com/example/provider/json/TripSerializer.java
+++ b/src/main/java/com/example/provider/json/TripSerializer.java
@@ -72,7 +72,7 @@ final class TripSerializer implements JsonSerializer<Trip> {
     return new Gson().toJsonTree(trip);
   }
 
-  static SerializedLocation createSerializedLocation(LatLng latLng) {
+  private static SerializedLocation createSerializedLocation(LatLng latLng) {
     return SerializedLocation.newBuilder()
         .setPoint(SerializedLatLng.newBuilder()
             .setLatitude(latLng.getLatitude())

--- a/src/main/java/com/example/provider/json/TripSerializer.java
+++ b/src/main/java/com/example/provider/json/TripSerializer.java
@@ -31,52 +31,26 @@ final class TripSerializer implements JsonSerializer<Trip> {
 
   @Override
   public JsonElement serialize(Trip src, Type typeOfSrc, JsonSerializationContext context) {
-    LatLng pickupLatLng = src.getPickupPoint().getPoint();
     Waypoint pickupWaypoint =
         Waypoint.newBuilder()
-            .setLocation(SerializedLocation.newBuilder()
-                .setPoint(SerializedLatLng.newBuilder()
-                    .setLatitude(pickupLatLng.getLatitude())
-                    .setLongitude(pickupLatLng.getLongitude())
-                    .setLatitude_(pickupLatLng.getLatitude())
-                    .setLongitude_(pickupLatLng.getLongitude())
-                    .build())
-                .build())
+            .setLocation(createSerializedLocation(src.getPickupPoint().getPoint()))
             .setWaypointType(WaypointType.PICKUP_WAYPOINT_TYPE)
             .build();
 
-    LatLng dropoffLatLng = src.getDropoffPoint().getPoint();
     Waypoint dropoffWaypoint =
         Waypoint.newBuilder()
-            .setLocation(SerializedLocation.newBuilder()
-                .setPoint(SerializedLatLng.newBuilder()
-                    .setLatitude(dropoffLatLng.getLatitude())
-                    .setLongitude(dropoffLatLng.getLongitude())
-                    .setLatitude_(dropoffLatLng.getLatitude())
-                    .setLongitude_(dropoffLatLng.getLongitude())
-                    .build())
-                .build())
+            .setLocation(createSerializedLocation(src.getDropoffPoint().getPoint()))
             .setWaypointType(WaypointType.DROP_OFF_WAYPOINT_TYPE)
             .build();
 
     List<Waypoint> intermediateWaypoints =
         src.getIntermediateDestinationsList().stream()
             .map(
-                destination -> {
-                    LatLng latLng = destination.getPoint();
-                    return Waypoint.newBuilder()
-                        .setLocation(SerializedLocation.newBuilder()
-                            .setPoint(SerializedLatLng.newBuilder()
-                                .setLatitude(latLng.getLatitude())
-                                .setLongitude(latLng.getLongitude())
-                                .setLatitude_(latLng.getLatitude())
-                                .setLongitude_(latLng.getLongitude())
-                                .build())
-                            .build())
+                destination ->
+                    Waypoint.newBuilder()
+                        .setLocation(createSerializedLocation(destination.getPoint()))
                         .setWaypointType(WaypointType.INTERMEDIATE_DESTINATION_WAYPOINT_TYPE)
-                        .build();
-                }
-            )
+                        .build())
             .collect(Collectors.toList());
     ;
 
@@ -96,5 +70,16 @@ final class TripSerializer implements JsonSerializer<Trip> {
             .build();
 
     return new Gson().toJsonTree(trip);
+  }
+
+  static SerializedLocation createSerializedLocation(LatLng latLng) {
+    return SerializedLocation.newBuilder()
+        .setPoint(SerializedLatLng.newBuilder()
+            .setLatitude(latLng.getLatitude())
+            .setLongitude(latLng.getLongitude())
+            .setLatitude_(latLng.getLatitude())
+            .setLongitude_(latLng.getLongitude())
+            .build())
+        .build();
   }
 }


### PR DESCRIPTION
The provider currently serializes `LatLng` objects, which are protobuf objects, using Gson directly. So it returns the latitude and longitude with an `_` suffix along with internal protobuf properties that are not relevant to the users, such as
```json
{
  "latitude_": 37.7748999,
  "longitude_": -122.4194,
  "memoizedIsInitialized": -1,
  "unknownFields": {
    "fields": {},
    "fieldsDescending": {}
  },
  "memoizedSize": -1,
  "memoizedHashCode": 0
}
```

This PR makes the provider return the latitude and longitude without the `_` suffix. However, since the sample apps are still relying on the underscore, this PR also makes the provider return the latitude and longitude with `_` for backward compatibility. The `latitude_` and `longitude_` keys will be removed once all the sample apps are updated to use `latitude` and `longitude` .
```json
{
  "latitude": 37.7748999,
  "longitude": -122.4194,
  "latitude_": 37.7748999,
  "longitude_": -122.4194
}
```