### PR TITLE
feat: Add index.html with basic diagnostics

### DIFF
--- a/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/webapp/WEB-INF/appengine-web.xml
@@ -19,4 +19,6 @@
        Delete this to use the socket API, which is more performant but could
        conceivably lead to different behavior. -->
   <url-stream-handler>urlfetch</url-stream-handler>
+
+  <public-root>/static</public-root>
 </appengine-web-app>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -12,4 +12,8 @@
   <listener>
     <listener-class>com.example.provider.SampleProviderGuiceServletContextListener</listener-class>
   </listener>
+
+  <welcome-file-list>
+    <welcome-file>index.html</welcome-file>
+  </welcome-file-list>
 </web-app>

--- a/src/main/webapp/static/index.html
+++ b/src/main/webapp/static/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Sample Apps Provider</title>
+  <link rel="stylesheet" href="main.css">
+</head>
+<body>
+    <h1>Sample apps provider</h3>
+    <strong>The server is now running, please see below for a status report.</strong>
+
+    <div class="status-area">
+        Driver token:
+        <div id="driver-token-status"></div>
+    </div>
+
+    <div class="status-area">
+        Consumer token:
+        <div id="consumer-token-status"></div>
+    </div>
+    
+    <script src="main.js"></script>
+</body>
+</html>

--- a/src/main/webapp/static/main.css
+++ b/src/main/webapp/static/main.css
@@ -1,0 +1,11 @@
+.error-label {
+  color: red;
+}
+
+.success-label {
+  color: green;
+}
+  
+.status-area {
+  margin: 10px;
+}

--- a/src/main/webapp/static/main.js
+++ b/src/main/webapp/static/main.js
@@ -1,0 +1,33 @@
+(() => {
+  const getSuccessMessage = (entity) =>
+      `Server has successfully created a token for a test ${entity}.`;
+
+  const getErrorMessage = (entity) => `Failed to create token for a test ${
+      entity}. Please make sure the Provider and service account information are properly configured in 'src/main/resources/config.properties'.`;
+
+  const driverStatusLabel = document.getElementById('driver-token-status');
+  const consumerStatusLabel = document.getElementById('consumer-token-status');
+
+
+  const fetchToken = (entity, labelElement) => {
+    fetch(`/token/${entity}/sample-entity-id`)
+        .then(
+            (response) => {
+              if (response.status == 200) {
+                labelElement.innerText = getSuccessMessage(entity);
+                labelElement.classList.add('success-label');
+                return;
+              }
+
+              labelElement.innerText = getErrorMessage(entity);
+              labelElement.classList.add('error-label');
+            },
+            () => {
+              labelElement.innerText = getErrorMessage(entity);
+              labelElement.classList.add('error-label');
+            });
+  };
+
+  fetchToken('driver', driverStatusLabel);
+  fetchToken('consumer', consumerStatusLabel);
+})();


### PR DESCRIPTION
feat: Add index.html with basic diagnostics

This creates a 'index.html' page which will be the default '/' for the server.
The page just indicates that the server has been started and tries to generate a token for a Driver/Consumer to make sure everything has been properly setup.
