### PR TITLE
fix: Remove latitude_/longitude_ from LatLng JSON

### DIFF
--- a/src/main/java/com/example/provider/json/SerializedLatLng.java
+++ b/src/main/java/com/example/provider/json/SerializedLatLng.java
@@ -24,12 +24,6 @@ abstract class SerializedLatLng {
 
   abstract double longitude();
 
-  // For backward compatibility.
-  abstract double latitude_();
-
-  // For backward compatibility.
-  abstract double longitude_();
-
   static Builder newBuilder() {
     return new AutoValue_SerializedLatLng.Builder();
   }
@@ -39,10 +33,6 @@ abstract class SerializedLatLng {
     abstract Builder setLatitude(double latitude);
 
     abstract Builder setLongitude(double longitude);
-
-    abstract Builder setLatitude_(double latitude_);
-
-    abstract Builder setLongitude_(double longitude_);
 
     abstract SerializedLatLng build();
   }

--- a/src/main/java/com/example/provider/json/TripSerializer.java
+++ b/src/main/java/com/example/provider/json/TripSerializer.java
@@ -77,8 +77,6 @@ final class TripSerializer implements JsonSerializer<Trip> {
         .setPoint(SerializedLatLng.newBuilder()
             .setLatitude(latLng.getLatitude())
             .setLongitude(latLng.getLongitude())
-            .setLatitude_(latLng.getLatitude())
-            .setLongitude_(latLng.getLongitude())
             .build())
         .build();
   }


### PR DESCRIPTION
Now that all the sample apps (Java, Kotlin, Swift, and Objective-C) have been updated to use `latitude`/`longtitude` instead of `latitude_`/`longtitude_`, we can remove `latitude_`/`longtitude_` from the LatLng JSON.