### PR TITLE
fix: Remove nonexistent status check

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -24,7 +24,6 @@ branchProtectionRules:
   requiresStrictStatusChecks: false
   requiredStatusCheckContexts:
     - 'cla/google'
-    - 'test'
     - 'snippet-bot check'
     - 'header-check'
   requiredApprovingReviewCount: 1
@@ -34,7 +33,6 @@ branchProtectionRules:
   requiresStrictStatusChecks: false
   requiredStatusCheckContexts:
     - 'cla/google'
-    - 'test'
     - 'snippet-bot-check'
     - 'header-check'
   requiredApprovingReviewCount: 1


### PR DESCRIPTION
#21 added a new status check that refers to a nonexistent "test" workflow and is currently blocking all new PRs. The request for adding tests should have been created as a feature request on the Issues page instead.