### PR TITLE
feat: Allow clients to specify 'tripType' for 'POST'

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ and the dropoff points are provided and a new trip is configured. If there is an
 existing vehicle, the sample provider will match the vehicle with the trip.
 
 The `intermediateDestinations` field is optional and it's used to support multi-destination trips.
+
+The `tripType` field is optional. The possible values are `EXCLUSIVE` and `SHARED`. In case it is not provided, the provider will default to `EXCLUSIVE`.
 ```
 POST /trip/new
 ```
@@ -200,7 +202,8 @@ Sample request body:
       "latitude": 5.44,
       "longitude": 2.43
     }
-  ]
+  ],
+  "tripType": "EXCLUSIVE"
 }
 ```
 

--- a/src/main/java/com/example/provider/utils/TripUtils.java
+++ b/src/main/java/com/example/provider/utils/TripUtils.java
@@ -46,7 +46,8 @@ public final class TripUtils {
       String vehicleId,
       LatLng pickup,
       LatLng dropoff,
-      LatLng[] intermediateDestinationsLatLng) {
+      LatLng[] intermediateDestinationsLatLng,
+      TripType tripType) {
     TerminalLocation pickupPoint = TerminalLocation.newBuilder().setPoint(pickup).build();
 
     TerminalLocation dropoffPoint = TerminalLocation.newBuilder().setPoint(dropoff).build();
@@ -55,7 +56,7 @@ public final class TripUtils {
         Trip.newBuilder()
             .setName(getTripNameFromId(tripId))
             .setVehicleId(vehicleId)
-            .setTripType(TripType.EXCLUSIVE)
+            .setTripType(tripType)
             .setPickupPoint(pickupPoint)
             .setDropoffPoint(dropoffPoint)
             .setNumberOfPassengers(DEFAULT_NUM_PASSENGERS);


### PR DESCRIPTION
Allows clients to specify the 'tripType' for a 'Trip' to create. 
This is part of the series to allow creation of 'Shared pool' trips.

