### PR TITLE
feat: Allow settings supportedTripTypes/maximumCapacity for vehicle creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,18 @@ Sample response:
 {
   "name": "providers/testProvider/vehicles/testVehicle",
   "vehicleState": "ONLINE",
-  "currentTripsIds": ["testTrip"]
+  "currentTripsIds": ["testTrip"],
+  "supportedTripTypes": ["EXCLUSIVE"],
+  "backToBackEnabled": true,
+  "maximumCapacity": 5
 }
 ```
 
 #### POST
 
 Creates a new vehicle given the vehicle ID. The vehicle ID is given in the body
-with the field `vehicleId`.
+with the field `vehicleId`. The attributes that can be specified are: `supportedTripTypes`, `backToBackEnabled`, and `maximumCapacity`.
+
 
 ```
 POST /vehicle/new
@@ -127,7 +131,10 @@ POST /vehicle/new
 Sample request body:
 ```json
 {
-  "vehicleId": "testVehicle"
+  "vehicleId": "testVehicle",
+  "supportedTripTypes": ["EXCLUSIVE"],
+  "backToBackEnabled": false,
+  "maximumCapacity": 5
 }
 ```
 

--- a/src/main/java/com/example/provider/json/SerializedVehicle.java
+++ b/src/main/java/com/example/provider/json/SerializedVehicle.java
@@ -15,6 +15,7 @@
 package com.example.provider.json;
 
 import com.google.auto.value.AutoValue;
+import google.maps.fleetengine.v1.TripType;
 import java.util.List;
 
 /**
@@ -30,6 +31,12 @@ abstract class SerializedVehicle {
   abstract String vehicleState();
   /** List of assigned trip Ids for vehicle */
   abstract List<String> currentTripsIds();
+  /** Back to back enabled */
+  abstract boolean backToBackEnabled();
+  /** Maximum capacity */
+  abstract int maximumCapacity();
+  /** Supported trip types */
+  abstract List<TripType> supportedTripTypes();
 
   static Builder newBuilder() {
     return new AutoValue_SerializedVehicle.Builder();
@@ -59,6 +66,27 @@ abstract class SerializedVehicle {
      * @param currentTripsIds current list of trip ids in Fleet Engine.
      */
     abstract Builder setCurrentTripsIds(List<String> currentTripsIds);
+
+    /**
+     * Setter for the backToBackEnabled setting for the vehicle.
+     *
+     * @param backToBackEnabled indicates if vehicle supports B2B trips.
+     */
+    abstract Builder setBackToBackEnabled(boolean backToBackEnabled);
+
+    /**
+     * Setter for the maximum passenger capacity.
+     *
+     * @param maximumCapacity vehicle maximum passengers capacity.
+     */
+    abstract Builder setMaximumCapacity(int maximumCapacity);
+
+    /**
+     * Setter for the list of supported trip types for the vehicle.
+     *
+     * @param supportedTripTypes list of supported trip types.
+     */
+    abstract Builder setSupportedTripTypes(List<TripType> supportedTripTypes);
 
     abstract SerializedVehicle build();
   }

--- a/src/main/java/com/example/provider/json/VehicleSerializer.java
+++ b/src/main/java/com/example/provider/json/VehicleSerializer.java
@@ -35,6 +35,9 @@ final class VehicleSerializer implements JsonSerializer<Vehicle> {
             .setName(src.getName())
             .setVehicleState(src.getVehicleState().name())
             .setCurrentTripsIds(src.getCurrentTripsList())
+            .setBackToBackEnabled(src.getBackToBackEnabled())
+            .setSupportedTripTypes(src.getSupportedTripTypesList())
+            .setMaximumCapacity(src.getMaximumCapacity())
             .build();
 
     return new Gson().toJsonTree(vehicle);

--- a/src/main/java/com/example/provider/utils/VehicleUtils.java
+++ b/src/main/java/com/example/provider/utils/VehicleUtils.java
@@ -15,6 +15,7 @@
  */
 package com.example.provider.utils;
 
+import com.google.common.collect.ImmutableList;
 import com.google.type.LatLng;
 import google.maps.fleetengine.v1.TripType;
 import google.maps.fleetengine.v1.Vehicle;
@@ -35,7 +36,6 @@ public final class VehicleUtils {
   /** Default longitude for vehicle creation located to Google MTV. */
   private static final double DEFAULT_LONGITUDE = -122.073884;
 
-  private static final int MAX_CAPACITY = 4;
   private static final int DEFAULT_SPEED = 30;
   private static final double SPEED_ACCURACY = 1.0;
 
@@ -52,13 +52,17 @@ public final class VehicleUtils {
    *
    * <p>TODO(b/153661805) Adding support for custom parameters.
    */
-  public static final Vehicle createVehicle(String vehicleId, Boolean backToBackEnabled) {
+  public static final Vehicle createVehicle(
+      String vehicleId,
+      Boolean backToBackEnabled,
+      int maximumCapacity,
+      ImmutableList<TripType> supportedTripTypes) {
     return Vehicle.newBuilder()
         .setName(getVehicleName(vehicleId))
         .setVehicleState(VehicleState.ONLINE)
-        .setMaximumCapacity(MAX_CAPACITY)
+        .setMaximumCapacity(maximumCapacity)
         .setVehicleType(VehicleType.newBuilder().setCategory(Category.AUTO))
-        .addSupportedTripTypes(TripType.EXCLUSIVE)
+        .addAllSupportedTripTypes(supportedTripTypes)
         .setLastLocation(getVehicleLocation())
         .setBackToBackEnabled(backToBackEnabled)
         .build();


### PR DESCRIPTION
Allows clients so specify a list of 'supported trip types' and 'maximum vehicle capacity' during creation.
It also serializes the mentioned values 

This is part of the series to allow creating 'Shared pool' trips.