### PR TITLE
feat: Support updating 'Vehicle' entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,24 @@ Sample request body:
 }
 ```
 
+#### PUT
+
+Updates a vehicle with the attributes provided. The vehicle ID is supplied in the url path.
+The attributes that can be modified are: `supportedTripTypes`, `backToBackEnabled`, and `maximumCapacity`.
+
+```
+PUT /vehicle/:vehicleId
+```
+
+Sample request body:
+```json
+{
+  "supportedTripTypes": ["EXCLUSIVE"],
+  "backToBackEnabled": false,
+  "maximumCapacity": 5
+}
+```
+
 ### Trip
 
 #### GET

--- a/src/main/java/com/example/provider/utils/ServletUtils.java
+++ b/src/main/java/com/example/provider/utils/ServletUtils.java
@@ -14,11 +14,13 @@
  */
 package com.example.provider.utils;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.example.provider.json.ErrorResponse;
 import com.example.provider.json.GsonProvider;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.MediaType;
 
@@ -42,5 +44,20 @@ public final class ServletUtils {
     ErrorResponse errorResponse = ErrorResponse.create(message, status);
     response.setStatus(status);
     response.getWriter().write(GsonProvider.get().toJson(errorResponse));
+  }
+
+  /**
+   * Extracts the 'ID' piece of a URL request. Use for REST endpoints where ID is supplied in that
+   * format.
+   *
+   * @throws IllegalArgumentException if path is not contained in the Request URL.
+   */
+  public static String getEntityIdFromRequestPath(HttpServletRequest request)
+      throws IllegalArgumentException {
+    if (isNullOrEmpty(request.getPathInfo())) {
+      throw new IllegalArgumentException("Request is missing ID from the URL path.");
+    }
+
+    return request.getPathInfo().substring(1);
   }
 }


### PR DESCRIPTION
Adds a 'PUT' endpoint for 'Vehicle'.
This allows updating settings for a 'Vehicle' such as supported trip types, back to back enabled, and maximum capacity.

This is part of the series to support creation of 'Shared pool' trips.