### PR TITLE
feat: support ordering waypoints for Shared pooling

### DIFF
--- a/src/main/java/com/example/provider/ServletState.java
+++ b/src/main/java/com/example/provider/ServletState.java
@@ -110,12 +110,12 @@ class ServletState {
   }
 
   /** Checks if there are any trips created waiting for match. */
-  public synchronized boolean hasTripPendingMatch() {
-    return tripsPendingMatches.peek() != null;
+  public synchronized Trip peekTripToMatch() {
+    return tripsPendingMatches.peek();
   }
 
   /** Gets the next trip in the queue waiting for match. */
-  public synchronized Trip getNextTripToMatch() {
+  public synchronized Trip pollTripToMatch() {
     return tripsPendingMatches.poll();
   }
 

--- a/src/main/java/com/example/provider/TripMatcher.java
+++ b/src/main/java/com/example/provider/TripMatcher.java
@@ -15,18 +15,26 @@
  */
 package com.example.provider;
 
+import static java.util.stream.Collectors.toList;
+
 import com.example.provider.auth.grpcservice.AuthenticatedGrpcServiceProvider;
-import com.example.provider.utils.VehicleUtils;
+import com.example.provider.utils.TripUtils;
 import com.google.inject.Inject;
 import com.google.protobuf.FieldMask;
 import google.maps.fleetengine.v1.GetTripRequest;
-import google.maps.fleetengine.v1.GetVehicleRequest;
+import google.maps.fleetengine.v1.TerminalLocation;
 import google.maps.fleetengine.v1.Trip;
 import google.maps.fleetengine.v1.TripServiceClient;
 import google.maps.fleetengine.v1.TripStatus;
+import google.maps.fleetengine.v1.TripType;
+import google.maps.fleetengine.v1.TripWaypoint;
 import google.maps.fleetengine.v1.UpdateTripRequest;
 import google.maps.fleetengine.v1.Vehicle;
 import google.maps.fleetengine.v1.VehicleServiceClient;
+import google.maps.fleetengine.v1.VehicleState;
+import google.maps.fleetengine.v1.WaypointType;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
 import javax.inject.Singleton;
 
@@ -49,26 +57,46 @@ class TripMatcher {
   }
 
   /** Determines if the given vehicle is ready to take a match based on current state. */
-  public boolean isVehicleReadyForMatch() {
-    String vehicleId = servletState.getVehicleId();
+  private synchronized boolean isVehicleReadyForMatch(Vehicle vehicle) {
+    Trip potentialTripMatch = servletState.peekTripToMatch();
 
-    if (servletState.hasTripPendingMatch() == false) {
+    if (potentialTripMatch == null) {
       return false;
     }
 
-    GetVehicleRequest getVehicleRequest =
-        GetVehicleRequest.newBuilder().setName(VehicleUtils.getVehicleName(vehicleId)).build();
-
-    Vehicle vehicle = authenticatedServerVehicleService.getVehicle(getVehicleRequest);
+    if (vehicle.getVehicleState() != VehicleState.ONLINE) {
+      return false;
+    }
 
     int numberOfTripsAssigned = vehicle.getCurrentTripsList().size();
 
-    if (numberOfTripsAssigned >= 2) {
-      return false;
-    }
-
     if (numberOfTripsAssigned == 0) {
       return true;
+    }
+
+    /**
+     * If both vehicle and trip support 'Shared pool', always match as long as there's capacity. We
+     * only compare 'Vehicle maximum capacity' vs 'Trip number of passengers' the 'waypoints
+     * computation logic will only try to insert the 'Trip' at a given point if there's capacity.
+     * That means, that in case the 'Vehicle maximum capacity' equals 'Trip number of passengers',
+     * the 'Trip will be added at the end of the 'waypoints' list.
+     */
+    List<TripType> vehicleSupportedTripTypes = vehicle.getSupportedTripTypesList();
+    boolean vehicleSupportsSharedTrips = vehicleSupportedTripTypes.contains(TripType.SHARED);
+    boolean isTripMatchShareable = potentialTripMatch.getTripType() == TripType.SHARED;
+
+    if (vehicleSupportsSharedTrips
+        && isTripMatchShareable
+        && vehicle.getMaximumCapacity() >= potentialTripMatch.getNumberOfPassengers()) {
+      return true;
+    }
+
+    /**
+     * In case there's more than 1 trip assigned to the 'Vehicle' and there's no 'Shared pool'
+     * supported, then provider will try to assign as 'B2B' trip.
+     */
+    if (numberOfTripsAssigned >= 2) {
+      return false;
     }
 
     if (vehicle.getBackToBackEnabled() == false) {
@@ -82,25 +110,60 @@ class TripMatcher {
 
     Trip trip = authenticatedServerTripService.getTrip(getTripRequest);
 
+    /** For B2B trips, only trigger match is the 'Vehicle active trip' is beyond 'PICKUP'. */
     return trip.getTripStatus() != TripStatus.ENROUTE_TO_PICKUP
         && trip.getTripStatus() != TripStatus.ARRIVED_AT_PICKUP
         && trip.getTripStatus() != TripStatus.NEW;
   }
 
-  /** Assigns a trip ready to match to the given vehicle. */
-  public synchronized void triggerMatching() {
-    String vehicleId = servletState.getVehicleId();
+  /** Tries to match the 'next trip' in the pending matches list to the active 'Vehicle'. */
+  public synchronized boolean triggerMatching(Vehicle vehicle, String vehicleId) {
+    if (!isVehicleReadyForMatch(vehicle)) {
+      return false;
+    }
 
-    logger.info(String.format("triggerMatching() vehicleId: %s", vehicleId));
+    Trip tripToMatch = servletState.pollTripToMatch();
 
-    Trip tripToMatch = servletState.getNextTripToMatch();
+    logger.info(
+        String.format(
+            "triggerMatching() vehicleId: %s tripName: %s", vehicleId, tripToMatch.getName()));
 
-    UpdateTripRequest updateRequest =
-        UpdateTripRequest.newBuilder()
-            .setName(tripToMatch.getName())
-            .setTrip(Trip.newBuilder().setVehicleId(vehicleId).build())
-            .setUpdateMask(FieldMask.newBuilder().addPaths("vehicle_id").build())
-            .build();
+    String tripToMatchId = TripUtils.getTripIdFromName(tripToMatch.getName());
+    UpdateTripRequest updateRequest;
+
+    int insertIndex = getIndexForTripInsertion(vehicle, tripToMatch);
+
+    /**
+     * If the insertIndex is greater or equal than zero, that means provider will try to create a
+     * 'Shared pool' for the 'Trip'. Otherwise, it will not explicitly set 'VehicleWaypoints' and
+     * will let 'FleetEngine' assign the trip to the end of the 'waypoints' list.
+     */
+    if (insertIndex >= 0) {
+      List<TripWaypoint> computedVehicleWaypoints =
+          getComputedWaypointsForSharedPool(vehicle, tripToMatch, tripToMatchId, insertIndex);
+
+      updateRequest =
+          UpdateTripRequest.newBuilder()
+              .setName(tripToMatch.getName())
+              .setTrip(
+                  Trip.newBuilder()
+                      .setVehicleId(vehicleId)
+                      .addAllVehicleWaypoints(computedVehicleWaypoints)
+                      .build())
+              .setUpdateMask(
+                  FieldMask.newBuilder()
+                      .addPaths("vehicle_id")
+                      .addPaths("vehicle_waypoints")
+                      .build())
+              .build();
+    } else {
+      updateRequest =
+          UpdateTripRequest.newBuilder()
+              .setName(tripToMatch.getName())
+              .setTrip(Trip.newBuilder().setVehicleId(vehicleId).build())
+              .setUpdateMask(FieldMask.newBuilder().addPaths("vehicle_id").build())
+              .build();
+    }
 
     Trip updatedTrip = authenticatedServerTripService.updateTrip(updateRequest);
     servletState.getActiveTripsMap().put(updatedTrip.getName(), updatedTrip);
@@ -109,5 +172,130 @@ class TripMatcher {
         String.format(
             "triggerMatching() completed vehicleId: %s tripName: %s",
             vehicleId, tripToMatch.getName()));
+
+    return true;
+  }
+
+  /**
+   * In case it has been determined that the 'Trip' to match will be part of a 'Shared pool', this
+   * method then is responsible for creating a 'waypoints' list where the given 'Trip' waypoints
+   * will be inserted (position is given by `insertIndex`).
+   */
+  private static synchronized List<TripWaypoint> getComputedWaypointsForSharedPool(
+      Vehicle vehicle, Trip tripToMatch, String tripToMatchId, int insertIndex) {
+    List<TripWaypoint> vehicleWaypoints = vehicle.getWaypointsList();
+    List<TripWaypoint> computedVehicleWaypoints = new ArrayList<>();
+    computedVehicleWaypoints.addAll(vehicleWaypoints.subList(0, insertIndex));
+
+    computedVehicleWaypoints.add(
+        TripWaypoint.newBuilder()
+            .setLocation(tripToMatch.getPickupPoint())
+            .setTripId(tripToMatchId)
+            .setWaypointType(WaypointType.PICKUP_WAYPOINT_TYPE)
+            .build());
+
+    computedVehicleWaypoints.add(vehicleWaypoints.get(insertIndex));
+
+    List<TerminalLocation> intermediateDestinationsList =
+        tripToMatch.getIntermediateDestinationsList();
+
+    List<TripWaypoint> intermediateDestinationWaypoints =
+        intermediateDestinationsList.stream()
+            .map(
+                location ->
+                    TripWaypoint.newBuilder()
+                        .setLocation(location)
+                        .setTripId(tripToMatchId)
+                        .setWaypointType(WaypointType.INTERMEDIATE_DESTINATION_WAYPOINT_TYPE)
+                        .build())
+            .collect(toList());
+
+    computedVehicleWaypoints.addAll(intermediateDestinationWaypoints);
+
+    computedVehicleWaypoints.add(
+        TripWaypoint.newBuilder()
+            .setLocation(tripToMatch.getDropoffPoint())
+            .setTripId(tripToMatchId)
+            .setWaypointType(WaypointType.DROP_OFF_WAYPOINT_TYPE)
+            .build());
+
+    computedVehicleWaypoints.addAll(
+        vehicleWaypoints.subList(insertIndex + 1, vehicleWaypoints.size()));
+
+    return computedVehicleWaypoints;
+  }
+
+  /**
+   * Calculates the index at where a 'Trip' could be inserted to create a 'Shared pool'. The
+   * provider will try to insert the 'Trip' in before the last 'dropoff' waypoint where there is
+   * capacity. It is worth noting that this might not be the optimal order but works for
+   * demonstration purpose. In practice, the implementation should take in consideration resources
+   * such as: time, distance.
+   *
+   * @return Returns a -1 if the 'Trip' should be inserted at the end of the waypoints list (B2B or
+   *     Exclusive). Otherwise, returns the index (based on the 'vehicleWaypoints') where the 'Trip'
+   *     could be inserted.
+   */
+  private synchronized int getIndexForTripInsertion(Vehicle vehicle, Trip tripToMatch) {
+    if (tripToMatch.getTripType() != TripType.SHARED) {
+      return -1;
+    }
+
+    if (!vehicle.getSupportedTripTypesList().contains(TripType.SHARED)) {
+      return -1;
+    }
+
+    List<String> currentTrips = vehicle.getCurrentTripsList();
+
+    if (currentTrips.isEmpty()) {
+      return -1;
+    }
+
+    int numberOfPassengers = 0;
+
+    // Calculate number of passengers currently in the vehicle (have already been picked up).
+    for (String tripId : currentTrips) {
+      Trip trip = servletState.getTrip(tripId);
+
+      boolean isTripPassengerPickedUp =
+          trip.getTripStatus() == TripStatus.ENROUTE_TO_DROPOFF
+              || trip.getTripStatus() == TripStatus.ENROUTE_TO_INTERMEDIATE_DESTINATION
+              || trip.getTripStatus() == TripStatus.ARRIVED_AT_INTERMEDIATE_DESTINATION;
+
+      if (isTripPassengerPickedUp) {
+        numberOfPassengers += trip.getNumberOfPassengers();
+      }
+    }
+
+    List<TripWaypoint> vehicleWaypoints = vehicle.getWaypointsList();
+
+    int insertIndex = -1;
+    int iterationIndex = 0;
+
+    /**
+     * Calculate the number of passengers that will be in the car after every 'waypoint'. It then
+     * finds the last 'Dropoff' waypoint where 'Trip' can be inserted.
+     */
+    for (TripWaypoint waypoint : vehicleWaypoints) {
+      Trip waypointTrip = servletState.getTrip(waypoint.getTripId());
+
+      if (waypoint.getWaypointType() == WaypointType.PICKUP_WAYPOINT_TYPE) {
+        numberOfPassengers += waypointTrip.getNumberOfPassengers();
+      } else if (waypoint.getWaypointType() == WaypointType.DROP_OFF_WAYPOINT_TYPE) {
+        boolean isThereVehicleCapacity =
+            (numberOfPassengers + tripToMatch.getNumberOfPassengers())
+                <= vehicle.getMaximumCapacity();
+
+        if (tripToMatch.getTripType() == TripType.SHARED && isThereVehicleCapacity) {
+          insertIndex = iterationIndex;
+        }
+
+        numberOfPassengers -= waypointTrip.getNumberOfPassengers();
+      }
+
+      iterationIndex++;
+    }
+
+    return insertIndex;
   }
 }

--- a/src/main/java/com/example/provider/VehicleServlet.java
+++ b/src/main/java/com/example/provider/VehicleServlet.java
@@ -103,8 +103,7 @@ public class VehicleServlet extends HttpServlet {
     logger.info(String.format("Vehicle:\n%s", vehicle));
 
     if (vehicle != null) {
-      if (tripMatcher.isVehicleReadyForMatch()) {
-        tripMatcher.triggerMatching();
+      if (tripMatcher.triggerMatching(vehicle, vehicleId)) {
         vehicle = vehicleServiceClient.getVehicle(getVehicleRequest);
       }
     }

--- a/src/main/java/com/example/provider/utils/TripUtils.java
+++ b/src/main/java/com/example/provider/utils/TripUtils.java
@@ -21,6 +21,8 @@ import com.google.type.LatLng;
 import google.maps.fleetengine.v1.TerminalLocation;
 import google.maps.fleetengine.v1.Trip;
 import google.maps.fleetengine.v1.TripType;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /** Utility class for Trip. */
@@ -30,14 +32,21 @@ public final class TripUtils {
       String.format("providers/%s", SampleProviderUtils.providerProperties.providerId());
   public static final String TRIP_NAME_FORMAT =
       "providers/" + SampleProviderUtils.providerProperties.providerId() + "/trips/%s";
-
+  private static final Pattern TRIP_NAME_PATTERN =
+      Pattern.compile("/?providers/([\\S]+)/trips/([\\S]+)");
   private static final int DEFAULT_NUM_PASSENGERS = 1;
 
   private TripUtils() {}
 
-  /** Returns fleetengine formatted trip name from trip ID. */
+  /** Returns Fleet Engine formatted trip name from trip ID. */
   public static String getTripNameFromId(String tripId) {
     return String.format(TRIP_NAME_FORMAT, tripId);
+  }
+
+  /** Extracts the 'Trip Id' from the Fleet Engine formatted 'Trip name'. */
+  public static String getTripIdFromName(String tripName) {
+    Matcher matcher = TRIP_NAME_PATTERN.matcher(tripName);
+    return matcher.matches() ? matcher.group(2) : null;
   }
 
   /** Creates exclusive trip with {@code DEFAULT_NUM_PASSENGERS} and given params. */


### PR DESCRIPTION
feat: support ordering waypoints for Shared pooling

Supports ordering 'Vehicle' waypoints for 'Shared trips' to created 'Shared pools'.

For Trips/Vehicles that don't support 'SHARED' trips, the changes are backwards compatible and should still work.