### PR TITLE
feat: serialize list of vehicle waypoints to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ Sample response:
   "name": "providers/testProvider/vehicles/testVehicle",
   "vehicleState": "ONLINE",
   "currentTripsIds": ["testTrip"],
+  "waypoints": [
+    {
+      "location": {
+        "point": { "latitude": 3.45, "longitude": 4.4 }
+      },
+      "waypointType": "PICKUP_WAYPOINT_TYPE",
+      "tripId": "testTrip"
+    },
+    {
+      "location": {
+        "point": { "latitude": 3.44, "longitude": 4.43 }
+      },
+      "waypointType": "DROP_OFF_WAYPOINT_TYPE",
+      "tripId": "testTrip"
+    }
+  ],
   "supportedTripTypes": ["EXCLUSIVE"],
   "backToBackEnabled": true,
   "maximumCapacity": 5
@@ -181,13 +197,15 @@ Sample response:
         "location": {
           "point": { "latitude": 3.45, "longitude": 4.4 }
         },
-        "waypointType": "PICKUP_WAYPOINT_TYPE"
+        "waypointType": "PICKUP_WAYPOINT_TYPE",
+        "tripId": "testTrip"
       },
       {
         "location": {
           "point": { "latitude": 3.44, "longitude": 4.43 }
         },
-        "waypointType": "DROP_OFF_WAYPOINT_TYPE"
+        "waypointType": "DROP_OFF_WAYPOINT_TYPE",
+        "tripId": "testTrip"
       }
     ]
   }

--- a/src/main/java/com/example/provider/json/SerializationUtils.java
+++ b/src/main/java/com/example/provider/json/SerializationUtils.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.provider.json;
+
+import com.google.type.LatLng;
+
+/** Utility class for Serialization related logic. */
+public final class SerializationUtils {
+  /** Creates a SerializedLocation object based on the supplied LatLng. */
+  public static SerializedLocation createSerializedLocation(LatLng latLng) {
+    return SerializedLocation.newBuilder()
+        .setPoint(
+            SerializedLatLng.newBuilder()
+                .setLatitude(latLng.getLatitude())
+                .setLongitude(latLng.getLongitude())
+                .build())
+        .build();
+  }
+}

--- a/src/main/java/com/example/provider/json/SerializedVehicle.java
+++ b/src/main/java/com/example/provider/json/SerializedVehicle.java
@@ -29,6 +29,8 @@ abstract class SerializedVehicle {
   abstract String name();
   /** Current state of the vehicle given by fleetengine. */
   abstract String vehicleState();
+  /** List of remanining waypoints. Ex: Waypoints that the vehicle will visit next. */
+  abstract List<Waypoint> waypoints();
   /** List of assigned trip Ids for vehicle */
   abstract List<String> currentTripsIds();
   /** Back to back enabled */
@@ -66,6 +68,13 @@ abstract class SerializedVehicle {
      * @param currentTripsIds current list of trip ids in Fleet Engine.
      */
     abstract Builder setCurrentTripsIds(List<String> currentTripsIds);
+
+    /**
+     * Setter for the remaining waypoints for the vehicle.
+     *
+     * @param waypoints list of remaining waypoints.
+     */
+    abstract Builder setWaypoints(List<Waypoint> waypoints);
 
     /**
      * Setter for the backToBackEnabled setting for the vehicle.

--- a/src/main/java/com/example/provider/json/TripSerializer.java
+++ b/src/main/java/com/example/provider/json/TripSerializer.java
@@ -15,12 +15,12 @@
 package com.example.provider.json;
 
 import com.example.provider.json.Waypoint.WaypointType;
+import com.example.provider.utils.TripUtils;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-import com.google.type.LatLng;
 import google.maps.fleetengine.v1.Trip;
 import java.lang.reflect.Type;
 import java.util.List;
@@ -31,16 +31,22 @@ final class TripSerializer implements JsonSerializer<Trip> {
 
   @Override
   public JsonElement serialize(Trip src, Type typeOfSrc, JsonSerializationContext context) {
+    String tripId = TripUtils.getTripIdFromName(src.getName());
+
     Waypoint pickupWaypoint =
         Waypoint.newBuilder()
-            .setLocation(createSerializedLocation(src.getPickupPoint().getPoint()))
+            .setLocation(
+                SerializationUtils.createSerializedLocation(src.getPickupPoint().getPoint()))
             .setWaypointType(WaypointType.PICKUP_WAYPOINT_TYPE)
+            .setTripId(tripId)
             .build();
 
     Waypoint dropoffWaypoint =
         Waypoint.newBuilder()
-            .setLocation(createSerializedLocation(src.getDropoffPoint().getPoint()))
+            .setLocation(
+                SerializationUtils.createSerializedLocation(src.getDropoffPoint().getPoint()))
             .setWaypointType(WaypointType.DROP_OFF_WAYPOINT_TYPE)
+            .setTripId(tripId)
             .build();
 
     List<Waypoint> intermediateWaypoints =
@@ -48,8 +54,10 @@ final class TripSerializer implements JsonSerializer<Trip> {
             .map(
                 destination ->
                     Waypoint.newBuilder()
-                        .setLocation(createSerializedLocation(destination.getPoint()))
+                        .setLocation(
+                            SerializationUtils.createSerializedLocation(destination.getPoint()))
                         .setWaypointType(WaypointType.INTERMEDIATE_DESTINATION_WAYPOINT_TYPE)
+                        .setTripId(tripId)
                         .build())
             .collect(Collectors.toList());
     ;
@@ -70,14 +78,5 @@ final class TripSerializer implements JsonSerializer<Trip> {
             .build();
 
     return new Gson().toJsonTree(trip);
-  }
-
-  private static SerializedLocation createSerializedLocation(LatLng latLng) {
-    return SerializedLocation.newBuilder()
-        .setPoint(SerializedLatLng.newBuilder()
-            .setLatitude(latLng.getLatitude())
-            .setLongitude(latLng.getLongitude())
-            .build())
-        .build();
   }
 }

--- a/src/main/java/com/example/provider/json/VehicleSerializer.java
+++ b/src/main/java/com/example/provider/json/VehicleSerializer.java
@@ -14,12 +14,16 @@
  */
 package com.example.provider.json;
 
+import static java.util.stream.Collectors.toList;
+
+import com.example.provider.utils.WaypointUtils;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import google.maps.fleetengine.v1.Vehicle;
 import java.lang.reflect.Type;
+import java.util.List;
 
 /**
  * Serializer for vehicle object to provide relevant information to its clients.
@@ -30,11 +34,26 @@ final class VehicleSerializer implements JsonSerializer<Vehicle> {
 
   @Override
   public JsonElement serialize(Vehicle src, Type typeOfSrc, JsonSerializationContext context) {
+    List<Waypoint> waypoints =
+        src.getWaypointsList().stream()
+            .map(
+                waypoint ->
+                    Waypoint.newBuilder()
+                        .setTripId(waypoint.getTripId())
+                        .setWaypointType(
+                            WaypointUtils.getWaypointTypeString(waypoint.getWaypointType()))
+                        .setLocation(
+                            SerializationUtils.createSerializedLocation(
+                                waypoint.getLocation().getPoint()))
+                        .build())
+            .collect(toList());
+
     SerializedVehicle vehicle =
         SerializedVehicle.newBuilder()
             .setName(src.getName())
             .setVehicleState(src.getVehicleState().name())
             .setCurrentTripsIds(src.getCurrentTripsList())
+            .setWaypoints(waypoints)
             .setBackToBackEnabled(src.getBackToBackEnabled())
             .setSupportedTripTypes(src.getSupportedTripTypesList())
             .setMaximumCapacity(src.getMaximumCapacity())

--- a/src/main/java/com/example/provider/json/Waypoint.java
+++ b/src/main/java/com/example/provider/json/Waypoint.java
@@ -18,13 +18,15 @@ import com.google.auto.value.AutoValue;
 
 /** Represents a vehicle waypoint. */
 @AutoValue
-abstract class Waypoint {
+public abstract class Waypoint {
 
   /** Geo location of the waypoint. */
   abstract SerializedLocation location();
 
   /** Type of waypoint. */
   abstract WaypointType waypointType();
+
+  abstract String tripId();
 
   static Builder newBuilder() {
     return new AutoValue_Waypoint.Builder();
@@ -36,6 +38,8 @@ abstract class Waypoint {
     abstract Builder setLocation(SerializedLocation location);
 
     abstract Builder setWaypointType(WaypointType type);
+
+    abstract Builder setTripId(String tripId);
 
     abstract Waypoint build();
   }

--- a/src/main/java/com/example/provider/utils/WaypointUtils.java
+++ b/src/main/java/com/example/provider/utils/WaypointUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.provider.utils;
+
+import com.example.provider.json.Waypoint.WaypointType;
+
+/** Utility class for waypoint related logic. */
+public final class WaypointUtils {
+  /** Returns a Provider 'WaypointType' value based on the provided FleetEngine enum value. */
+  public static WaypointType getWaypointTypeString(
+      google.maps.fleetengine.v1.WaypointType waypointType) {
+    switch (waypointType) {
+      case PICKUP_WAYPOINT_TYPE:
+        return WaypointType.PICKUP_WAYPOINT_TYPE;
+
+      case DROP_OFF_WAYPOINT_TYPE:
+        return WaypointType.DROP_OFF_WAYPOINT_TYPE;
+
+      case INTERMEDIATE_DESTINATION_WAYPOINT_TYPE:
+        return WaypointType.INTERMEDIATE_DESTINATION_WAYPOINT_TYPE;
+
+      default:
+        throw new IllegalArgumentException("Invalid waypoint type");
+    }
+  }
+}


### PR DESCRIPTION
Enable serializing the list of waypoints for the Vehicle so clients can rely on it for state management. 
Currently, clients rely on 'Trip.waypoints' for state tracking but this will change as we integrate 'Shared pooling'.