### PR TITLE
fix: prevent trips pending match queue from getting stuck

### DIFF
--- a/src/main/java/com/example/provider/ServletState.java
+++ b/src/main/java/com/example/provider/ServletState.java
@@ -20,6 +20,7 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 import javax.inject.Singleton;
@@ -47,7 +48,7 @@ class ServletState {
   private String routeToken;
 
   /** Queue of trips created awaiting to be matched. */
-  private LinkedList<Trip> tripsPendingMatches = new LinkedList<>();
+  private List<Trip> tripsPendingMatches = new LinkedList<>();
 
   /** List of current active trips. */
   private Map<String, Trip> tripsMap = new HashMap<>();
@@ -109,14 +110,14 @@ class ServletState {
     return tripsMap.isEmpty();
   }
 
-  /** Checks if there are any trips created waiting for match. */
-  public synchronized Trip peekTripToMatch() {
-    return tripsPendingMatches.peek();
+  /** Gets the list of pending matches. */
+  public synchronized List<Trip> getTripsPendingMatches() {
+    return tripsPendingMatches;
   }
 
-  /** Gets the next trip in the queue waiting for match. */
-  public synchronized Trip pollTripToMatch() {
-    return tripsPendingMatches.poll();
+  /** Removes the given trip from the queue of pending matches.  */
+  public synchronized void removeTripPendingMatch(Trip trip) {
+    tripsPendingMatches.remove(trip);
   }
 
   public synchronized Map<String, Trip> getActiveTripsMap() {

--- a/src/main/java/com/example/provider/ServletStatePropertyChangeListener.java
+++ b/src/main/java/com/example/provider/ServletStatePropertyChangeListener.java
@@ -37,7 +37,6 @@ import java.util.logging.Logger;
 class ServletStatePropertyChangeListener implements PropertyChangeListener {
   private static final Logger logger =
       Logger.getLogger(ServletStatePropertyChangeListener.class.getName());
-  private static final String TRIP_VEHICLE_ID_PROPERTY = "vehicle_id";
   private static final String TRIP_STATUS_PROPERTY = "trip_status";
   private final TripServiceClient authenticatedServerTripService;
   private final ServletState servletState;

--- a/src/main/java/com/example/provider/TokenServlet.java
+++ b/src/main/java/com/example/provider/TokenServlet.java
@@ -23,7 +23,6 @@ import com.google.fleetengine.auth.token.FleetEngineTokenType;
 import com.google.fleetengine.auth.token.TripClaims;
 import com.google.fleetengine.auth.token.VehicleClaims;
 import com.google.fleetengine.auth.token.factory.signer.SigningTokenException;
-import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.logging.Logger;
 import javax.inject.Inject;

--- a/src/main/java/com/example/provider/TripServlet.java
+++ b/src/main/java/com/example/provider/TripServlet.java
@@ -68,7 +68,6 @@ public final class TripServlet extends HttpServlet {
 
   private final AuthenticatedGrpcServiceProvider grpcServiceProvider;
   private final ServletState servletState;
-  private final TripMatcher tripMatcher;
 
   private static final String SUPPORTED_POST_LINK = "/new";
 
@@ -90,11 +89,9 @@ public final class TripServlet extends HttpServlet {
   @Inject
   public TripServlet(
       ServletState servletState,
-      AuthenticatedGrpcServiceProvider grpcServiceProvider,
-      TripMatcher tripMatcher) {
+      AuthenticatedGrpcServiceProvider grpcServiceProvider) {
     this.servletState = servletState;
     this.grpcServiceProvider = grpcServiceProvider;
-    this.tripMatcher = tripMatcher;
   }
 
   @Override


### PR DESCRIPTION
- The 'Trip matching' mechanism relies on a queue to determine the next trip to match. Currently, the logic only tries to match the top/head of the queue and if match can't be done (Example: Vehicle doesn't support trip type), then the queue gets stuck. This fixes the problem by moving through the queue looking for matches.

- Removes a few unused variables/imports from different files