### PR TITLE
Add vehicle attribute serializer & deserializer

### DIFF
--- a/src/main/java/com/example/provider/json/GsonProvider.java
+++ b/src/main/java/com/example/provider/json/GsonProvider.java
@@ -19,6 +19,7 @@ import com.google.gson.GsonBuilder;
 import com.google.type.LatLng;
 import google.maps.fleetengine.v1.Trip;
 import google.maps.fleetengine.v1.Vehicle;
+import google.maps.fleetengine.v1.VehicleAttribute;
 import java.util.Date;
 
 /**
@@ -46,6 +47,8 @@ public final class GsonProvider {
         .registerTypeAdapter(Trip.class, new TripSerializer())
         .registerTypeAdapter(Date.class, new DateSerializer())
         .registerTypeAdapter(LatLng.class, new LatLngDeserializer())
+        .registerTypeAdapter(VehicleAttribute.class, new VehicleAttributeSerializer())
+        .registerTypeAdapter(VehicleAttribute.class, new VehicleAttributeDeserializer())
         .setPrettyPrinting();
     gson = gsonBuilder.create();
     return gson;

--- a/src/main/java/com/example/provider/json/SerializedVehicleAttribute.java
+++ b/src/main/java/com/example/provider/json/SerializedVehicleAttribute.java
@@ -1,0 +1,29 @@
+package com.example.provider.json;
+
+import com.google.auto.value.AutoValue;
+
+/** Class used to represent a serialized Vehicle attribute object. */
+@AutoValue
+abstract class SerializedVehicleAttribute {
+
+  /** Key of the vehicle attribute. */
+  abstract String key();
+
+  /** Value of the vehicle attribute. */
+  abstract String value();
+
+  static Builder newBuilder() {
+    return new AutoValue_SerializedVehicleAttribute.Builder();
+  }
+
+  /** Builder for this serialized vehicle attribute. */
+  @AutoValue.Builder
+  abstract static class Builder {
+
+    abstract Builder setKey(String key);
+
+    abstract Builder setValue(String value);
+
+    abstract SerializedVehicleAttribute build();
+  }
+}

--- a/src/main/java/com/example/provider/json/VehicleAttributeDeserializer.java
+++ b/src/main/java/com/example/provider/json/VehicleAttributeDeserializer.java
@@ -1,0 +1,37 @@
+package com.example.provider.json;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import google.maps.fleetengine.v1.VehicleAttribute;
+import java.lang.reflect.Type;
+
+/** JSON Deserializer for vehicleAttribute objects. */
+final class VehicleAttributeDeserializer implements JsonDeserializer<VehicleAttribute> {
+  private static final String KEY_FIELD = "key";
+  private static final String VALUE_FIELD = "value";
+  private static final String NOT_PROVIDED_MESSAGE = "%s not provided";
+
+  @Override
+  public VehicleAttribute deserialize(
+      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    JsonObject jsonObject = json.getAsJsonObject();
+    if (!jsonObject.has(KEY_FIELD)) {
+      String errorMsg = String.format(NOT_PROVIDED_MESSAGE, KEY_FIELD);
+      throw new JsonParseException(errorMsg);
+    }
+    if (!jsonObject.has(VALUE_FIELD)) {
+      String errorMsg = String.format(NOT_PROVIDED_MESSAGE, VALUE_FIELD);
+      throw new JsonParseException(errorMsg);
+    }
+    String vehicleAttributeKey = jsonObject.get(KEY_FIELD).getAsString();
+    String vehicleAttributeValue = jsonObject.get(VALUE_FIELD).getAsString();
+    return VehicleAttribute.newBuilder()
+        .setKey(vehicleAttributeKey)
+        .setValue(vehicleAttributeValue)
+        .build();
+  }
+}

--- a/src/main/java/com/example/provider/json/VehicleAttributeDeserializer.java
+++ b/src/main/java/com/example/provider/json/VehicleAttributeDeserializer.java
@@ -19,16 +19,20 @@ final class VehicleAttributeDeserializer implements JsonDeserializer<VehicleAttr
       JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {
     JsonObject jsonObject = json.getAsJsonObject();
+
     if (!jsonObject.has(KEY_FIELD)) {
       String errorMsg = String.format(NOT_PROVIDED_MESSAGE, KEY_FIELD);
       throw new JsonParseException(errorMsg);
     }
+
     if (!jsonObject.has(VALUE_FIELD)) {
       String errorMsg = String.format(NOT_PROVIDED_MESSAGE, VALUE_FIELD);
       throw new JsonParseException(errorMsg);
     }
+
     String vehicleAttributeKey = jsonObject.get(KEY_FIELD).getAsString();
     String vehicleAttributeValue = jsonObject.get(VALUE_FIELD).getAsString();
+
     return VehicleAttribute.newBuilder()
         .setKey(vehicleAttributeKey)
         .setValue(vehicleAttributeValue)

--- a/src/main/java/com/example/provider/json/VehicleAttributeSerializer.java
+++ b/src/main/java/com/example/provider/json/VehicleAttributeSerializer.java
@@ -1,0 +1,23 @@
+package com.example.provider.json;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import google.maps.fleetengine.v1.VehicleAttribute;
+import java.lang.reflect.Type;
+
+/** JSON Serializer for vehicleAttribute objects. */
+public class VehicleAttributeSerializer implements JsonSerializer<VehicleAttribute> {
+
+  @Override
+  public JsonElement serialize(
+      VehicleAttribute src, Type typeOfSrc, JsonSerializationContext context) {
+    SerializedVehicleAttribute vehicleAttribute =
+        SerializedVehicleAttribute.newBuilder()
+            .setKey(src.getKey())
+            .setValue(src.getValue())
+            .build();
+    return new Gson().toJsonTree(vehicleAttribute);
+  }
+}


### PR DESCRIPTION
VehicleAttribute uses the fields "key_" and "value_" so this PR adds a serializer to remove the suffix when returning the JSON response. It also adds a deserializer so client request payload can directly be converted to FE VehicleAttribute objects.

Before: 
```json
{
  "key_": "test_key",
  "value_": "test_value",
  "memoizedIsInitialized": -1,
  "unknownFields": {
    "fields": {},
    "fieldsDescending": {}
  },
  "memoizedSize": -1,
  "memoizedHashCode": 0
}
```
After:
```json
{
  "key": "test_key",
  "value": "test_value",
}
```