### PR TITLE
build: fix "Waiting for status to be reported" for required test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  dependabot:
+  test:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Small fix which update the job name from "dependabot" to the expected "test".