### PR TITLE
Remove urlfetch as url-stream-handler because it cannot get the AppEngine default user.

### DIFF
--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Wed Nov 10 12:14:41 PST 2021
-sdk.dir=/usr/local/google/home/shawnlu/Android/Sdk

--- a/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/webapp/WEB-INF/appengine-web.xml
@@ -15,10 +15,5 @@
        threads. -->
   <threadsafe>true</threadsafe>
 
-  <!-- Continue to use urlfetch to open URLs in Java.
-       Delete this to use the socket API, which is more performant but could
-       conceivably lead to different behavior. -->
-  <url-stream-handler>urlfetch</url-stream-handler>
-
   <public-root>/static</public-root>
 </appengine-web-app>


### PR DESCRIPTION
1.) Remove urlfetch as url-stream-handler because it cannot get the AppEngine service user when deployed to AppEngine. 
More info here: https://cloud.google.com/appengine/docs/legacy/standard/java/issue-requests#using_url_fetch

2.) Remove local.properties file. Should not be checked into VCS.