### PR TITLE
chore: clean up routeToken code from provider

### DIFF
--- a/src/main/java/com/example/provider/ServletState.java
+++ b/src/main/java/com/example/provider/ServletState.java
@@ -45,7 +45,6 @@ class ServletState {
   private static final Logger logger = Logger.getLogger(ServletState.class.getName());
 
   private String vehicleId;
-  private String routeToken;
 
   /** Queue of trips created awaiting to be matched. */
   private List<Trip> tripsPendingMatches = new LinkedList<>();
@@ -70,14 +69,6 @@ class ServletState {
     }
 
     this.vehicleId = vehicleId;
-  }
-
-  public synchronized void setRouteToken(String routeToken) {
-    this.routeToken = routeToken;
-  }
-
-  public synchronized String getRouteToken() {
-    return routeToken;
   }
 
   /** Adds a trip to the queue of trips to match as well as to the map of active trips. */

--- a/src/main/java/com/example/provider/TripServlet.java
+++ b/src/main/java/com/example/provider/TripServlet.java
@@ -109,9 +109,8 @@ public final class TripServlet extends HttpServlet {
         grpcServiceProvider.getAuthenticatedTripService();
 
     Trip trip = authenticatedServerTripService.getTrip(getTripRequest);
-    String routeToken = Strings.nullToEmpty(servletState.getRouteToken());
 
-    response.getWriter().print(GsonProvider.get().toJson(TripData.create(trip, routeToken)));
+    response.getWriter().print(GsonProvider.get().toJson(TripData.create(trip)));
 
     logger.info(response.toString());
     response.getWriter().flush();

--- a/src/main/java/com/example/provider/json/TripData.java
+++ b/src/main/java/com/example/provider/json/TripData.java
@@ -22,9 +22,7 @@ import google.maps.fleetengine.v1.Trip;
 public abstract class TripData {
   abstract Trip trip();
 
-  abstract String routeToken();
-
-  public static TripData create(Trip trip, String routeToken) {
-    return new AutoValue_TripData(trip, routeToken);
+  public static TripData create(Trip trip) {
+    return new AutoValue_TripData(trip);
   }
 }


### PR DESCRIPTION
chore: clean up routeToken code from provider

The "RouteToken" functionality was not implemented completely when it was introduced and at this point it would be better to just clean up. Neither of the Android/iOS sample apps use this field.