### PR TITLE
build: Use Java 11 by default and set CORS headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ regarding the App Engine plugin with Gradle, go to this
 [website](https://cloud.google.com/appengine/docs/standard/java/using-gradle).
 
 Install and configure the following prerequisites:
-- Java 8 or 11. Make sure your environment is set to either of the two.
-  We recommend [SDKMan](https://sdkman.io/usage) for more convenient management of the Java version in your system.
+- Make sure your environment is set to Java 11.
 - Make sure that your Cloud project is set up on your Google account. Go to
   [Setting up and validating your Cloud project](https://cloud.google.com/appengine/docs/standard/java/using-gradle#setting_up_and_validating_your)
 - [gcloud CLI tool](https://cloud.google.com/sdk/install).
@@ -63,7 +62,7 @@ To run the server:
 `Caused by: java.lang.NoSuchMethodException: java.net.SocksSocketImpl.<init>()` or
 `Exception java.lang.NoClassDefFoundError: Could not initialize class org.codehaus.groovy.reflection.ReflectionCache [in thread "Daemon worker"]`
 
-- Make sure to set Java 8 or 11. We recommend [SDKMan](https://sdkman.io/usage) to manage this in your system.
+- Make sure to set 11. We recommend [SDKMan](https://sdkman.io/usage) to manage this in your system.
 
 `Error injecting constructor, com.google.auth.ServiceAccountSigner$SigningException: Failed to sign the provided bytes`
 - Fill in the required Fleet Engine configuration in `src/main/resources/config.properties`.

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@
  */
 buildscript {    // Configuration for building
   repositories {
+    google()
     mavenCentral()
   }
   dependencies {
@@ -47,10 +48,10 @@ apply plugin: 'com.google.protobuf'
 
 
 dependencies {
-  compile 'com.google.appengine:appengine-api-1.0-sdk:1.9.79'  // Latest App Engine Api's
+  implementation 'com.google.appengine:appengine-api-1.0-sdk:2.0.26'  // Latest App Engine Api's
   providedCompile 'javax.servlet:javax.servlet-api:3.1.0'
 
-  compile 'jstl:jstl:1.2'
+  implementation 'jstl:jstl:1.2'
 
   // Add dependencies here
   implementation 'com.google.maps:fleetengine-auth:1.9.1'
@@ -65,22 +66,22 @@ dependencies {
   implementation 'com.google.auto.value:auto-value-annotations:1.6.2'
   implementation 'com.google.guava:guava:16+'
   implementation 'com.google.auth:google-auth-library-oauth2-http:0+'
-  implementation 'io.grpc:grpc-protobuf:1.28.0'
-  implementation 'io.grpc:grpc-stub:1.28.0'
-  implementation 'io.grpc:grpc-netty:1.28.0'
+  implementation 'io.grpc:grpc-protobuf:1.62.2'
+  implementation 'io.grpc:grpc-stub:1.62.2'
+  implementation 'io.grpc:grpc-netty:1.62.2'
   implementation 'javax.ws.rs:jsr311-api:1.1.1'
-  implementation 'com.google.protobuf:protobuf-java:3.11.4'
+  implementation 'com.google.protobuf:protobuf-java:3.25.3'
   implementation 'javax.annotation:javax.annotation-api:1.2'
   implementation 'io.netty:netty-tcnative-boringssl-static:2.0.29.Final'
   annotationProcessor 'com.google.auto.value:auto-value:1.6.2'
 
-  testCompile 'junit:junit:4.12'
-  testCompile 'com.google.truth:truth:0.33'
-  testCompile 'org.mockito:mockito-all:1.10.19'
+  testImplementation 'junit:junit:4.12'
+  testImplementation 'com.google.truth:truth:0.33'
+  testImplementation 'org.mockito:mockito-all:1.10.19'
 
-  testCompile 'com.google.appengine:appengine-testing:+'
-  testCompile 'com.google.appengine:appengine-api-stubs:+'
-  testCompile 'com.google.appengine:appengine-tools-sdk:+'
+  testImplementation 'com.google.appengine:appengine-testing:+'
+  testImplementation 'com.google.appengine:appengine-api-stubs:+'
+  testImplementation 'com.google.appengine:appengine-tools-sdk:+'
 }
 
 // Always run unit tests
@@ -93,7 +94,7 @@ appengine {  // App Engine tasks configuration
   }
 
   deploy {   // deploy configuration
-    projectId = 'sample-provider-testeijr'
+    projectId = 'YOUR-CLOUD-PROJECT'
     version = '1'
   }
 }
@@ -113,8 +114,8 @@ test {
   }
 }
 
-group   = "com.example.appenginej8"        // Generated output GroupId
+group   = "com.example.appenginej11"        // Generated output GroupId
 version = "1.0-SNAPSHOT"       // Version in generated output
 
-sourceCompatibility = 1.8     // App Engine Flexible uses Java 8
-targetCompatibility = 1.8     // App Engine Flexible uses Java 8
+sourceCompatibility = 11
+targetCompatibility = 11

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {    // Configuration for building
     mavenCentral()
   }
   dependencies {
-    classpath 'com.google.cloud.tools:appengine-gradle-plugin:2.4.3'
+    classpath 'com.google.cloud.tools:appengine-gradle-plugin:2.4.5'
     classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.8'
   }
 }
@@ -55,22 +55,21 @@ dependencies {
 
   // Add dependencies here
   implementation 'com.google.maps:fleetengine-auth:1.11.0'
-  implementation('com.google.api:gax:2.48.0')
+  implementation 'com.google.api:gax:1.65.1'
   implementation 'com.google.maps:gapic-google-maps-fleetengine-v1-java:0.0.197'
 
   implementation 'com.auth0:java-jwt:3.10.2'
-  implementation('com.google.inject:guice:5.1.0')
+  implementation 'com.google.inject:guice:5.1.0'
   implementation 'com.google.inject.extensions:guice-servlet:5.1.0'
   implementation 'com.google.code.gson:gson:2.8.0'
   implementation 'com.google.auto.value:auto-value-annotations:1.6.2'
   implementation 'com.google.guava:guava:30.1-jre'
-  implementation 'io.grpc:grpc-protobuf:1.62.2'
-  implementation('io.grpc:grpc-stub:1.62.2')
-  implementation 'io.grpc:grpc-netty:1.62.2'
+  implementation 'io.grpc:grpc-protobuf:1.28.0'
+  implementation 'io.grpc:grpc-stub:1.28.0'
+  implementation 'io.grpc:grpc-netty:1.28.0'
   implementation 'javax.ws.rs:jsr311-api:1.1.1'
   implementation 'com.google.protobuf:protobuf-java:3.25.3'
   implementation 'javax.annotation:javax.annotation-api:1.2'
-  implementation 'io.netty:netty-tcnative-boringssl-static:2.0.29.Final'
   annotationProcessor 'com.google.auto.value:auto-value:1.6.2'
 
   testImplementation 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {    // Configuration for building
     mavenCentral()
   }
   dependencies {
-    classpath 'com.google.cloud.tools:appengine-gradle-plugin:2.4.3'    // Latest 1.x.x release
+    classpath 'com.google.cloud.tools:appengine-gradle-plugin:2.4.3'
     classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.8'
   }
 }
@@ -48,26 +48,24 @@ apply plugin: 'com.google.protobuf'
 
 
 dependencies {
-  implementation 'com.google.appengine:appengine-api-1.0-sdk:2.0.26'  // Latest App Engine Api's
-  providedCompile 'javax.servlet:javax.servlet-api:3.1.0'
+  implementation 'com.google.appengine:appengine-api-1.0-sdk:2.0.26'
+  compileOnly 'javax.servlet:javax.servlet-api:3.1.0' // Use compileOnly for provided dependencies
 
   implementation 'jstl:jstl:1.2'
 
   // Add dependencies here
-  implementation 'com.google.maps:fleetengine-auth:1.9.1'
-
-  implementation 'com.google.api:gax:1.65.1'
+  implementation 'com.google.maps:fleetengine-auth:1.11.0'
+  implementation('com.google.api:gax:2.48.0')
   implementation 'com.google.maps:gapic-google-maps-fleetengine-v1-java:0.0.197'
 
   implementation 'com.auth0:java-jwt:3.10.2'
-  implementation 'com.google.inject:guice:4.2.2'
-  implementation 'com.google.inject.extensions:guice-servlet:4.2.3'
+  implementation('com.google.inject:guice:5.1.0')
+  implementation 'com.google.inject.extensions:guice-servlet:5.1.0'
   implementation 'com.google.code.gson:gson:2.8.0'
   implementation 'com.google.auto.value:auto-value-annotations:1.6.2'
-  implementation 'com.google.guava:guava:16+'
-  implementation 'com.google.auth:google-auth-library-oauth2-http:0+'
+  implementation 'com.google.guava:guava:30.1-jre'
   implementation 'io.grpc:grpc-protobuf:1.62.2'
-  implementation 'io.grpc:grpc-stub:1.62.2'
+  implementation('io.grpc:grpc-stub:1.62.2')
   implementation 'io.grpc:grpc-netty:1.62.2'
   implementation 'javax.ws.rs:jsr311-api:1.1.1'
   implementation 'com.google.protobuf:protobuf-java:3.25.3'
@@ -82,6 +80,16 @@ dependencies {
   testImplementation 'com.google.appengine:appengine-testing:+'
   testImplementation 'com.google.appengine:appengine-api-stubs:+'
   testImplementation 'com.google.appengine:appengine-tools-sdk:+'
+}
+
+configurations.all {
+  withDependencies {
+    resolutionStrategy.eachDependency {
+      if (it.requested.group == 'com.google.guava' && it.requested.name == 'guava') {
+        it.useTarget("com.google.guava:guava:30.1-jre")
+      }
+    }
+  }
 }
 
 // Always run unit tests

--- a/build.gradle
+++ b/build.gradle
@@ -48,10 +48,9 @@ apply plugin: 'com.google.protobuf'
 
 
 dependencies {
-  implementation 'com.google.appengine:appengine-api-1.0-sdk:2.0.26'
+  compileOnly 'com.google.appengine:appengine-api-1.0-sdk:2.0.26'
   compileOnly 'javax.servlet:javax.servlet-api:3.1.0' // Use compileOnly for provided dependencies
-
-  implementation 'jstl:jstl:1.2'
+  compileOnly 'jstl:jstl:1.2'
 
   // Add dependencies here
   implementation 'com.google.maps:fleetengine-auth:1.11.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/example/provider/utils/ServletUtils.java
+++ b/src/main/java/com/example/provider/utils/ServletUtils.java
@@ -32,6 +32,11 @@ public final class ServletUtils {
   public static void setStandardResponseHeaders(HttpServletResponse response) {
     response.setContentType(MediaType.APPLICATION_JSON);
     response.setCharacterEncoding(UTF_8.name());
+    response.addHeader("Access-Control-Allow-Origin", "*");
+    response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE, PUT");
+    response.setHeader("Access-Control-Allow-Headers", "Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+    response.setHeader("Access-Control-Allow-Credentials", "true");
+    response.setHeader("Access-Control-Max-Age", "3600");
   }
 
   /**

--- a/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <runtime>java8</runtime>
+  <runtime>java11</runtime>
 
   <!-- Replace YOUR-APPID-HERE before deploying.
        If you created an App Engine for Business (googleplex) app for Googlers
@@ -16,4 +16,12 @@
   <threadsafe>true</threadsafe>
 
   <public-root>/static</public-root>
+
+  <static-files>
+    <include path="/static" >
+      <http-header name="Access-Control-Allow-Origin"
+          value="*" />
+    </include>
+  </static-files>
+
 </appengine-web-app>


### PR DESCRIPTION
Move to use Java 11 by default, and set CORS headers.
- Java 8 is deprecated.
- CORS headers needed when deploying to AppEngine.
- Update some minor library versions as needed.
- Update Gradle to use latest v6.
